### PR TITLE
Fix build for mysql 8

### DIFF
--- a/ChangeLog.md
+++ b/ChangeLog.md
@@ -1,3 +1,7 @@
+## 0.1.6
+
+* Fix build for mysql 8
+
 ## 0.1.5
 
 * Add Semigroup instance for FieldFlags

--- a/Database/MySQL/Base/C.hsc
+++ b/Database/MySQL/Base/C.hsc
@@ -117,6 +117,8 @@ mysql_options ptr opt =
         withIntegral secs $ go (#const MYSQL_OPT_READ_TIMEOUT)
       WriteTimeout secs ->
         withIntegral secs $ go (#const MYSQL_OPT_WRITE_TIMEOUT)
+#if !defined(MARIADB_BASE_VERSION) && MYSQL_VERSION_ID >= 80000
+#else
       UseRemoteConnection ->
         go (#const MYSQL_OPT_USE_REMOTE_CONNECTION) nullPtr
       UseEmbeddedConnection ->
@@ -127,12 +129,16 @@ mysql_options ptr opt =
         useAsCString ip $ go (#const MYSQL_SET_CLIENT_IP)
       SecureAuth b ->
         withBool b $ go (#const MYSQL_SECURE_AUTH)
+#endif
       ReportDataTruncation b ->
         withBool b $ go (#const MYSQL_REPORT_DATA_TRUNCATION)
       Reconnect b ->
         withBool b $ go (#const MYSQL_OPT_RECONNECT)
+#if !defined(MARIADB_BASE_VERSION) && MYSQL_VERSION_ID >= 80000
+#else
       SSLVerifyServerCert b ->
         withBool b $ go (#const MYSQL_OPT_SSL_VERIFY_SERVER_CERT)
+#endif
       -- Other options are accepted by mysql_real_connect, so ignore them.
       _ -> return 0
   where

--- a/Database/MySQL/Base/Types.hsc
+++ b/Database/MySQL/Base/Types.hsc
@@ -259,14 +259,20 @@ data Option =
             | SharedMemoryBaseName ByteString
             | ReadTimeout Seconds
             | WriteTimeout Seconds
+#if !defined(MARIADB_BASE_VERSION) && MYSQL_VERSION_ID >= 80000
+#else
             | UseRemoteConnection
             | UseEmbeddedConnection
             | GuessConnection
             | ClientIP ByteString
+#endif
             | SecureAuth Bool
             | ReportDataTruncation Bool
             | Reconnect Bool
+#if !defined(MARIADB_BASE_VERSION) && MYSQL_VERSION_ID >= 80000
+#else
             | SSLVerifyServerCert Bool
+#endif
             -- Flags accepted by mysql_real_connect.
             | FoundRows
             | IgnoreSIGPIPE

--- a/include/mysql_signals.h
+++ b/include/mysql_signals.h
@@ -8,6 +8,10 @@
 
 #include "mysql.h"
 
+#if !defined(MARIADB_BASE_VERSION) && MYSQL_VERSION_ID >= 80000
+typedef char my_bool;
+#endif
+
 MYSQL *STDCALL _hs_mysql_real_connect(MYSQL *mysql, const char *host,
 				      const char *user,
 				      const char *passwd,

--- a/mysql.cabal
+++ b/mysql.cabal
@@ -1,5 +1,5 @@
 name:           mysql
-version:        0.1.5
+version:        0.1.6
 homepage:       https://github.com/paul-rouse/mysql
 bug-reports:    https://github.com/paul-rouse/mysql/issues
 synopsis:       A low-level MySQL client library.


### PR DESCRIPTION
`my_bool` and some `mysql_option` are removed in mysql 8. let's guard
the code with macro and make sure it builds against both mariadb-10.1.36 and
mysql-8.0.4.

Closes #33