### PR TITLE
Remove obsolete `fieldDefault` from `data Field`

### DIFF
--- a/Database/MySQL/Base/Types.hsc
+++ b/Database/MySQL/Base/Types.hsc
@@ -145,7 +145,6 @@ data Field = Field {
     , fieldOrigTable :: ByteString -- ^ Original table name, if table was an alias.
     , fieldDB :: ByteString        -- ^ Database for table.
     , fieldCatalog :: ByteString   -- ^ Catalog for table.
-    , fieldDefault :: Maybe ByteString   -- ^ Default value.
     , fieldLength :: Word          -- ^ Width of column (create length).
     , fieldMaxLength :: Word    -- ^ Maximum width for selected set.
     , fieldFlags :: FieldFlags        -- ^ Div flags.
@@ -216,9 +215,6 @@ peekField ptr = do
    <*> peekS ((#peek MYSQL_FIELD, org_table)) ((#peek MYSQL_FIELD, org_table_length))
    <*> peekS ((#peek MYSQL_FIELD, db)) ((#peek MYSQL_FIELD, db_length))
    <*> peekS ((#peek MYSQL_FIELD, catalog)) ((#peek MYSQL_FIELD, catalog_length))
-   <*> (if flags `hasAllFlags` flagNoDefaultValue
-       then pure Nothing
-       else Just <$> peekS ((#peek MYSQL_FIELD, def)) ((#peek MYSQL_FIELD, def_length)))
    <*> (uint <$> (#peek MYSQL_FIELD, length) ptr)
    <*> (uint <$> (#peek MYSQL_FIELD, max_length) ptr)
    <*> pure flags

--- a/mysql.cabal
+++ b/mysql.cabal
@@ -1,5 +1,5 @@
 name:           mysql
-version:        0.1.7.2
+version:        0.2.0.0
 homepage:       https://github.com/paul-rouse/mysql
 bug-reports:    https://github.com/paul-rouse/mysql/issues
 synopsis:       A low-level MySQL client library.


### PR DESCRIPTION
This field seems to be of little use and has been shown to be the cause
of hard to debug segfaults.

The not-so-recent documentation for libmysql at
https://dev.mysql.com/doc/c-api/5.7/en/c-api-data-structures.html
states about the `char *def`

> This is set only if you use mysql_list_fields().

moreover, the documentation also states at
https://dev.mysql.com/doc/c-api/5.7/en/mysql-list-fields.html

> As of MySQL 5.7.11, mysql_list_fields() is deprecated and will be removed
> in a future version of MySQL. Instead, use mysql_query() to execute
> a SHOW COLUMNS statement.

and finally the Haskell binding doesn't appear to even seem to bind the
`mysql_list_fields()` function in the first place. Moreover, the
mariadb-c-connector fork which has been supplanting libmysql in many
Linux distributions has been known to cause such segfaults.

Instead, the code incorrectly assumes the `char *def` field to be set
even when `mysql_list_fields()` was not used; and then it depends on
whether the MYSQL_FIELD struct happened to be allocated in zeroed out
memory region or not, on whether `char *def` and its associated
`def_length` field happen to be set to a zero or contain random garbage
resulting in either random HeapOverflow exceptions or straight out
memory access violations.

This patch simply removes the `fieldValue` field from `data Field` as
it appears to be of no use given the feature has long been effectively
obsoleted. This also requires a major version bump as per PVP.