### PR TITLE
Fix minor issue with JSON

### DIFF
--- a/Database/MySQL/Base/Types.hsc
+++ b/Database/MySQL/Base/Types.hsc
@@ -132,9 +132,7 @@ toType v = IntMap.findWithDefault oops (fromIntegral v) typeMap
       , ((#const MYSQL_TYPE_VAR_STRING), VarString)
       , ((#const MYSQL_TYPE_STRING), String)
       , ((#const MYSQL_TYPE_GEOMETRY), Geometry)
-#if defined(MYSQL_TYPE_JSON)
-      , ((#const MYSQL_TYPE_JSON), Json)
-#endif
+      , (245, Json)
       ]
 
 -- | A description of a field (column) of a table.


### PR DESCRIPTION
This PR is to fix an issue where JSON fields were not being recognized

This was discovered while i was working on prepared statements.

JSON has been supported by mysql since 2015 so it should be safe to assume that the _JSON type is defined in the .h file (this will mean that 5.7 is the lowest supported version of mysql, perhaps a shim to define the json type would be useful?)

Without this fix mysql-simple was still having issues with JSON fields. After making this change it worked. 