### PR TITLE
fix: add mariadb to extra-libraries in cabal file

### DIFF
--- a/mysql.cabal
+++ b/mysql.cabal
@@ -47,6 +47,8 @@ library
     Database.MySQL.Base.C
     Database.MySQL.Base.Types
 
+  extra-libraries: mariadb-embedded
+
   build-depends:
     base       < 5,
     bytestring >= 0.9 && < 1.0,
@@ -68,6 +70,7 @@ test-suite test
     type:            exitcode-stdio-1.0
     main-is:         main.hs
     hs-source-dirs:  test
+    extra-libraries: mariadb-embedded
     ghc-options:     -Wall
     default-language: Haskell2010
     build-depends:   base                    >= 4 && < 5


### PR DESCRIPTION
It's required by `mysql_config`.
Be friendly to programs that convert cabal files, such as nix.